### PR TITLE
Add FastMCP-compatible SSE server for PubChem MCP tool

### DIFF
--- a/servers/pubchem-mcp-server/python_version/README.md
+++ b/servers/pubchem-mcp-server/python_version/README.md
@@ -65,3 +65,7 @@ The server is configured to cache API responses to improve performance:
 - Optional: RDKit (for enhanced 3D structure generation)
 
 If RDKit is not available, the server will fall back to using a simplified SDF parser for XYZ format conversion.
+
+## FastMCP
+
+- python pubchem-mcp-server/python_version/server.py

--- a/servers/pubchem-mcp-server/python_version/server.py
+++ b/servers/pubchem-mcp-server/python_version/server.py
@@ -1,0 +1,23 @@
+import arxiv
+import json
+import os
+from typing import List
+from mcp.server.fastmcp import FastMCP
+from mcp_server import handle_tool_call
+mcp = FastMCP("pubchem", host="0.0.0.0",port=50001)
+@mcp.tool()
+def get_pubchem_data(query: str, format: str = 'JSON', include_3d: bool = False) -> str:
+    """
+    Get PubChem data for a given query.
+    """
+    return handle_tool_call("get_pubchem_data", {"query": query, "format": format, "include_3d": include_3d})
+
+@mcp.tool()
+def download_structure(cid: str, format: str = 'sdf') -> str:
+    """
+    Download a structure from PubChem.
+    """
+    return handle_tool_call("download_structure", {"cid": cid, "format": format})
+
+if __name__ == "__main__":
+    mcp.run(transport="sse")


### PR DESCRIPTION
This is a follow-up to #5. Adds a FastMCP-compatible server for unified SSE deployment. Based on original tool logic by @PhelanShao.