### PR TITLE
Add matbench property prediciton mcp server

### DIFF
--- a/servers/matbench_property_prediction/README.md
+++ b/servers/matbench_property_prediction/README.md
@@ -1,0 +1,24 @@
+# Matbench Property Prediction MCP Server
+Predict matbench properties using deep potential models, including refractive index(unitless), exfoliation energy (meV/atom), the DFT Voigt-Reuss-Hill average shear moduli in GPa, the DFT Voigt-Reuss-Hill average bulk moduli in GPa, formation energy in eV as calculated by the Materials Project, the band gap as calculated by PBE DFT from the Materials Project, heat of formation of the entire 5-atom perovskite cell in eV as calculated by RPBE GGA-DFT and frequency of the highest frequency optical phonon mode peak in units of 1/cm. If user did not mention specific matbench properties please calculate all supported matbench properties.
+
+## Usage
+
+```bash
+# Install dependencies
+uv sync
+
+# Run server
+python server.py --port 50001
+
+# Run with custom host
+python server.py --host localhost --port 50001
+
+# Enable debug logging
+python server.py --port 50001 --log-level DEBUG
+```
+
+## Example
+Input : 
+     Can you give me the frequency of the highest frequency optical phonon mode peak of structures in xxx?
+Output : 
+     The frequency of the highest frequency optical phonon mode peak for the structure "O32Si16" is approximately 1184.08 cm⁻¹.

--- a/servers/matbench_property_prediction/metadata.json
+++ b/servers/matbench_property_prediction/metadata.json
@@ -1,0 +1,7 @@
+{
+    "name": "matbench_property_prediction",
+    "description": "Predict matbench properties using deep potential models",
+    "author": "2043899742@qq.com",
+    "category": "materials",
+    "tools": ["predict_matbench_properties"]
+}

--- a/servers/matbench_property_prediction/pyproject.toml
+++ b/servers/matbench_property_prediction/pyproject.toml
@@ -8,12 +8,10 @@ dependencies = [
     "flask>=3.1.1",
     "scipy>=1.12.0",
     "ase>=3.22.1",
-    "seekpath>=2.0.1",
     "torchaudio",
     "torchvision",
     "deepmd-kit==3.1.0",  
     "numpy==1.26.4",
-    "dpdata", 
     "typing-extensions",  
     "pyyaml",
     "science-agent-sdk" 

--- a/servers/matbench_property_prediction/pyproject.toml
+++ b/servers/matbench_property_prediction/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "matbench-property_prediciton-mcp-server"
+version = "0.1.0"
+description = "Predict matbench properties using deep potential models"
+requires-python = ">=3.10,<3.12"
+dependencies = [
+    "requests>=2.32.3",
+    "flask>=3.1.1",
+    "scipy>=1.12.0",
+    "ase>=3.22.1",
+    "seekpath>=2.0.1",
+    "torchaudio",
+    "torchvision",
+    "deepmd-kit==3.1.0",  
+    "numpy==1.26.4",
+    "dpdata", 
+    "typing-extensions",  
+    "pyyaml",
+    "science-agent-sdk" 
+]
+
+[project.scripts]
+example-mcp = "server:main"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/servers/matbench_property_prediction/server.py
+++ b/servers/matbench_property_prediction/server.py
@@ -1,0 +1,211 @@
+import logging
+import numpy as np
+from pathlib import Path
+from typing import Optional, Literal, Tuple, Union, TypedDict, List, Dict
+
+from ase.io import write, read
+from ase import io
+
+import random
+import os
+import shutil
+import glob
+import pandas as pd
+import json
+
+from dp.agent.server import CalculationMCPServer
+
+from deepmd.infer.deep_property import DeepProperty
+
+# Setup logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+# Initialize MCP server
+mcp = CalculationMCPServer(
+    "MatbenchServer",
+    host="0.0.0.0",
+    port=50001
+)
+
+
+# ====== Tool 1: Predict Matbench Properties ======
+
+class MaterialProperties(TypedDict):
+    dielectric: float
+    jdft2d:     float
+    gvrh:     float
+    kvrh:      float
+    mp_e_form:      float
+    mp_gap:      float
+    perovskites:      float
+    phonons:        float
+
+MaterialData = Dict[str, MaterialProperties]
+
+class MultiPropertiesResult(TypedDict):
+    results: Path
+    properties: MaterialData
+    message: str
+
+@mcp.tool()
+def predict_matbench_properties(
+    structure_file: Path,
+    target_properties: Optional[List[str]]
+) -> MultiPropertiesResult:
+    """
+    Predict matbench properties using deep potential models, including refractive index(unitless), exfoliation energy (meV/atom), 
+    the DFT Voigt-Reuss-Hill average shear moduli in GPa, the DFT Voigt-Reuss-Hill average bulk moduli in GPa, formation energy 
+    in eV as calculated by the Materials Project, the band gap as calculated by PBE DFT from the Materials Project, heat of 
+    formation of the entire 5-atom perovskite cell in eV as calculated by RPBE GGA-DFT and frequency of the highest frequency 
+    optical phonon mode peak in units of 1/cm. If user did not mention specific matbench properties please calculate all supported matbench properties.
+
+    Args:
+        structure_file (Path): Path to structure file (.cif or POSCAR).
+        target_properties (Optional[List[str]]): Properties to calculate. 
+            Options: 
+              - "dielectric":    refractive index(unitless),
+              - "jdft2d":        exfoliation energy (meV/atom), 
+              - "gvrh":          the DFT Voigt-Reuss-Hill average shear moduli in GPa, 
+              - "kvrh":          the DFT Voigt-Reuss-Hill average bulk moduli in GPa,
+              - "mp_e_form":     formation energy in eV as calculated by the Materials Project,
+              - "mp_gap":        the band gap as calculated by PBE DFT from the Materials Project,
+              - "perovskites":   heat of formation of the entire 5-atom perovskite cell in eV as calculated by RPBE GGA-DFT,
+              - "phonons":       frequency of the highest frequency optical phonon mode peak in units of 1/cm, 
+            If None, all supported properties will be calculated.
+ 
+    """
+    def eval_properties(
+        structure,
+        model
+    ) -> float:
+        """
+          Predict structure property with DeepProperty
+
+          Args:
+            structure: Structure files
+            model: used model for property prediction
+        """
+
+        coords = structure.get_positions()
+        cells = structure.get_cell()
+        atom_types = structure.get_atomic_numbers()
+        atom_types = np.array([ii-1 for ii in atom_types])
+
+        #evaluate properties
+        dp_property = DeepProperty(model_file=str(model))
+        result = dp_property.eval(coords     = coords,
+                                  cells      = cells,
+                                  atom_types = atom_types
+                                  )
+
+        return result
+
+
+    try:
+        supported_properties = ["dielectric", "jdft2d", "gvrh", "kvrh", "mp_e_form", "mp_gap", "perovskites", "phonons"]
+        props_to_calc = target_properties or supported_properties
+
+        model = Path("/opt/models")
+        model_dirs = {
+          "dielectric":  model / "dielectric" / "model.ckpt.pt",
+          "jdft2d": model / "jdft2d"  / "model.ckpt.pt",
+          "gvrh": model / "gvrh"  / "model.ckpt.pt",
+          "kvrh":  model / "kvrh"   / "model.ckpt.pt",
+          "mp_e_form":  model / "mp_e_form"   / "model.ckpt.pt",
+          "mp_gap":  model / "mp_gap"   / "model.ckpt.pt",
+          "perovskites":  model / "perovskites"   / "model.ckpt.pt",
+          "phonons":    model / "phonons" / "model.ckpt.pt"
+        }
+
+
+        #Define props for atom
+        results: MaterialData = {}
+        props_results: MaterialProperties = {}
+
+        structure_file = Path(structure_file)
+        if not structure_file.exists():
+            return {"results": {}, "message": f"Structure file not found: {structure_file}"}
+
+        structures = sorted(structure_file.rglob("POSCAR*")) + sorted(structure_file.rglob("*.cif"))
+        for structure in structures:
+            try:
+               if structure.name.upper().startswith("POSCAR"):
+                  fmt = "vasp"
+               elif structure.suffix.lower() == ".cif":
+                  fmt = "cif"
+               else: 
+                  continue
+              
+               atom = io.read(str(structure), format=fmt)
+               formula = atom.get_chemical_formula()
+            except Exception as e:
+               return{
+                 "results": {},
+                 "properties": {},
+                 "message": f"Structure {structure} read failed!"
+               }
+            props_results = {} 
+            for prop in props_to_calc:
+                try:
+                    used_model = model_dirs[prop]
+                    if not used_model.exists():
+                       props_results[prop] = -1.0
+                       results[formula] = props_results
+                       return {
+                           "results": results,
+                           "message": f"Model file not found for {prop}: {used_model}"
+                       }
+
+                    if prop in ("kvrh", "gvrh"):
+                       value, = eval_properties(atom, used_model)
+                       props_results[prop] = 10 ** (float(value.item()))
+                    else:
+                       value, = eval_properties(atom, used_model)
+                       props_results[prop] = float(value.item())
+                except Exception as e:
+                       return{
+                         "results": {},
+                         "properties": {},
+                         "message": f"Structure {structure} {prop} prediction failed!"
+                       }
+            print(f"structure = {structure}")
+            props_results["path"] = str(structure)
+            results[formula] = props_results
+            print(results[formula]) 
+      
+        print(results) 
+        output_dir = Path("outputs")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        results_file = output_dir / "matbench_properties.json"
+        with open(results_file, "w") as f:
+             json.dump(results, f, indent=2)
+
+        # build a preview of the first 10 formulas + their props
+        preview_lines = []
+        for formula, props in list(results.items())[:10]:
+            # join each property into “key=value” pairs
+            prop_str = ", ".join(f"{k}={v}" for k, v in props.items())
+            preview_lines.append(f"{formula}: {prop_str}")
+        
+        message = "Predicted properties:\n" + "\n".join(preview_lines)
+
+        return {
+            "results": results_file,
+            "properties": results,
+            "message": message
+        }
+
+    except Exception as e:
+        return {
+            "results": {},
+            "properties": {},
+            "message": f"Unexpected error: {str(e)}"
+        }
+# ====== Run Server ======
+
+if __name__ == "__main__":
+    logging.info("Starting MatbenchServer on port 50001...")
+    mcp.run(transport="sse")

--- a/servers/matbench_property_prediction/server.py
+++ b/servers/matbench_property_prediction/server.py
@@ -14,24 +14,30 @@ import pandas as pd
 import json
 
 from dp.agent.server import CalculationMCPServer
-
 from deepmd.infer.deep_property import DeepProperty
 
-# Setup logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s"
-)
+def parse_args():
+    """Parse command line arguments for MCP server."""
+    parser = argparse.ArgumentParser(description="Matbench Property Prediction MCP Server")
+    parser.add_argument('--port', type=int, default=50001, help='Server port (default: 50001)')
+    parser.add_argument('--host', default='0.0.0.0', help='Server host (default: 0.0.0.0)')
+    parser.add_argument('--log-level', default='INFO',
+                       choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+                       help='Logging level (default: INFO)')
+    try:
+        args = parser.parse_args()
+    except SystemExit:
+        class Args:
+            port = 50001
+            host = '0.0.0.0'
+            log_level = 'INFO'
+        args = Args()
+    return args
 
-# Initialize MCP server
-mcp = CalculationMCPServer(
-    "MatbenchServer",
-    host="0.0.0.0",
-    port=50001
-)
+args = parse_args()
+mcp = FastMCP("MatbenchServer", port=args.port, host=args.host)
 
-
-# ====== Tool 1: Predict Matbench Properties ======
+# ====== Tool: Predict Matbench Properties ======
 
 class MaterialProperties(TypedDict):
     dielectric: float


### PR DESCRIPTION
Predict matbench properties using deep potential models, including refractive index(unitless), exfoliation energy (meV/atom), the DFT Voigt-Reuss-Hill average shear moduli in GPa, the DFT Voigt-Reuss-Hill average bulk moduli in GPa, formation energy in eV as calculated by the Materials Project, the band gap as calculated by PBE DFT from the Materials Project, heat of formation of the entire 5-atom perovskite cell in eV as calculated by RPBE GGA-DFT and frequency of the highest frequency optical phonon mode peak in units of 1/cm. If user did not mention specific matbench properties please calculate all supported matbench properties.